### PR TITLE
Updated JobWrapper to throw correct exception type

### DIFF
--- a/Quartz.Net/Quartz.Unity.40/UnityJobFactory.cs
+++ b/Quartz.Net/Quartz.Unity.40/UnityJobFactory.cs
@@ -125,10 +125,14 @@ namespace Quartz.Unity
                     RunningJob = (IJob)childContainer.Resolve(bundle.JobDetail.JobType);
                     RunningJob.Execute(context);
                 }
+                catch (JobExecutionException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
-                    throw new SchedulerConfigException(string.Format(CultureInfo.InvariantCulture,
-                        "Failed to instantiate Job '{0}' of type '{1}'",
+                    throw new JobExecutionException(string.Format(CultureInfo.InvariantCulture,
+                        "Failed to execute Job '{0}' of type '{1}'",
                         bundle.JobDetail.Key, bundle.JobDetail.JobType), ex);
                 }
                 finally


### PR DESCRIPTION
According to the Quartz.Net documentation
(http://www.quartz-scheduler.net/documentation/quartz-1.x/tutorial/more-about-jobs.html)
the Job.Execute method should only be throwing JobExecutionException so
I've updated accordingly.